### PR TITLE
Adding blurhash generation support for images with ACL policy

### DIFF
--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -7,7 +7,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
         const { data, where } = event.params;
 
         if ((data.mime && data.mime.startsWith('image/'))) {
-            data.blurhash = await strapi.plugin(PLUGIN_NAME).service('blurhash').generateBlurhash(data.url);
+            data.blurhash = await strapi.plugin(PLUGIN_NAME).service('blurhash').generateBlurhash(data);
         }
 
         if (eventType === 'beforeUpdate' && strapi.plugin(PLUGIN_NAME).config('regenerateOnUpdate') === true) {
@@ -17,7 +17,7 @@ export default ({ strapi }: { strapi: Strapi }) => {
             });
 
             if ((fullData.mime && fullData.mime.startsWith('image/')) && !fullData.blurhash) {
-                data.blurhash = await strapi.plugin(PLUGIN_NAME).service('blurhash').generateBlurhash(fullData.url);
+                data.blurhash = await strapi.plugin(PLUGIN_NAME).service('blurhash').generateBlurhash(fullData);
             }
         }
     };

--- a/server/services/blurhash.ts
+++ b/server/services/blurhash.ts
@@ -7,7 +7,7 @@ import { encode } from 'blurhash';
 
 const loadImage = (url: string): Promise<Buffer> => new Promise((resolve, reject) => {
     https.get(url, res => {
-        const data = [];
+        const data = new Array();
         res.on('data', chunk => data.push(chunk))
            .on('error', e => reject(e))
            .on('end', () => resolve(Buffer.concat(data)));
@@ -45,8 +45,12 @@ const testLoadAndEncode = async () => {
 };
 
 export default ({ strapi }: { strapi: Strapi }) => ({
-    async generateBlurhash(url) {
+    async generateBlurhash(file) {
         try {
+            const isPrivate = await strapi.plugin("upload").provider.isPrivate() ?? false
+            const { url } = isPrivate
+                ? await strapi.plugin("upload").provider.getSignedUrl(file)
+                : file;
             const image: Buffer = await loadImage(url);
             const hash = await encodeImage(image);
             return hash;


### PR DESCRIPTION
This fix allows the plugin to generate blurhash for images with an ACL set to `private` via the `isPrivate()` and `getSignedUrl()` methods exported from a provider interface.